### PR TITLE
Fix infinite loop on invalid backend

### DIFF
--- a/sms_engine/models.py
+++ b/sms_engine/models.py
@@ -53,9 +53,9 @@ class SMS(models.Model):
         if log_level is None:
             log_level = get_log_level()
 
-        backend_str = get_backend(self.backend_alias)
-        backend = import_attribute(backend_str)()
         try:
+            backend_str = get_backend(self.backend_alias)
+            backend = import_attribute(backend_str)()
             self.transaction_id = backend.send_message(self)
 
             message = ''

--- a/sms_engine/sms.py
+++ b/sms_engine/sms.py
@@ -117,7 +117,6 @@ def _send_bulk(smss, uses_multiprocessing=True, log_level=None, threads=4):
     failed_smses = []
     sms_count = len(smss)
 
-
     logger.info('Process started, sending %s sms' % sms_count)
 
     def send(sms):

--- a/sms_engine/sms.py
+++ b/sms_engine/sms.py
@@ -117,6 +117,7 @@ def _send_bulk(smss, uses_multiprocessing=True, log_level=None, threads=4):
     failed_smses = []
     sms_count = len(smss)
 
+
     logger.info('Process started, sending %s sms' % sms_count)
 
     def send(sms):

--- a/sms_engine/tests/test_send_queued.py
+++ b/sms_engine/tests/test_send_queued.py
@@ -72,14 +72,17 @@ class CommandTest(TestCase):
         """
         Empty backend alias shouldn't cause infinite loop
         """
+
+        # Empty backend alias will point to `default` backend
         sms = SMS.objects.create(to='+6280000000000', status=STATUS.queued)
         call_command('send_queued_sms', log_level=0)
         self.assertEqual(sms.logs.count(), 0)
         sms.refresh_from_db()
-        self.assertEqual(sms.status, STATUS.failed)
+        self.assertEqual(sms.status, STATUS.sent)
 
+        # No extra logs generated
         sms = SMS.objects.create(to='+6280000000000', status=STATUS.queued)
         call_command('send_queued_sms', log_level=1)
-        self.assertEqual(sms.logs.count(), 1)
+        self.assertEqual(sms.logs.count(), 0)
         sms.refresh_from_db()
-        self.assertEqual(sms.status, STATUS.failed)
+        self.assertEqual(sms.status, STATUS.sent)

--- a/sms_engine/tests/test_send_queued.py
+++ b/sms_engine/tests/test_send_queued.py
@@ -75,7 +75,11 @@ class CommandTest(TestCase):
         sms = SMS.objects.create(to='+6280000000000', status=STATUS.queued)
         call_command('send_queued_sms', log_level=0)
         self.assertEqual(sms.logs.count(), 0)
+        sms.refresh_from_db()
+        self.assertEqual(sms.status, STATUS.failed)
 
         sms = SMS.objects.create(to='+6280000000000', status=STATUS.queued)
         call_command('send_queued_sms', log_level=1)
         self.assertEqual(sms.logs.count(), 1)
+        sms.refresh_from_db()
+        self.assertEqual(sms.status, STATUS.failed)

--- a/sms_engine/tests/test_send_queued.py
+++ b/sms_engine/tests/test_send_queued.py
@@ -67,3 +67,15 @@ class CommandTest(TestCase):
                                  backend_alias='error')
         call_command('send_queued_sms', log_level=2)
         self.assertEqual(sms.logs.count(), 1)
+
+    def test_empty_backend_alias(self):
+        """
+        Empty backend alias shouldn't cause infinite loop
+        """
+        sms = SMS.objects.create(to='+6280000000000', status=STATUS.queued)
+        call_command('send_queued_sms', log_level=0)
+        self.assertEqual(sms.logs.count(), 0)
+
+        sms = SMS.objects.create(to='+6280000000000', status=STATUS.queued)
+        call_command('send_queued_sms', log_level=1)
+        self.assertEqual(sms.logs.count(), 1)


### PR DESCRIPTION
Specifying invalid backend alias will raise an exception on `message.dispatch` which is not handled correctly (cit should change the message's status to `failed`).

This causes infinite loop on `_send_bulk` method called from management command. This PR fix the bug